### PR TITLE
Parent user is explicitly received when using login-as, better types for normal user

### DIFF
--- a/nts-pool-management/src/templates/filters.rs
+++ b/nts-pool-management/src/templates/filters.rs
@@ -1,13 +1,22 @@
-use crate::models::user::{User, UserRole};
+use crate::{
+    auth::UnsafeLoggedInUser,
+    models::user::{User, UserRole},
+};
 
-pub fn is_logged_in(user: &Option<User>, _: &dyn askama::Values) -> askama::Result<bool> {
+pub fn is_logged_in(
+    user: &Option<UnsafeLoggedInUser>,
+    _: &dyn askama::Values,
+) -> askama::Result<bool> {
     Ok(user
         .as_ref()
         .map(|user| user.is_activated() && !user.is_disabled())
         .unwrap_or(false))
 }
 
-pub fn is_administrator(user: &Option<User>, _: &dyn askama::Values) -> askama::Result<bool> {
+pub fn is_administrator(
+    user: &Option<UnsafeLoggedInUser>,
+    _: &dyn askama::Values,
+) -> askama::Result<bool> {
     Ok(user
         .as_ref()
         .map(|user| {
@@ -16,7 +25,10 @@ pub fn is_administrator(user: &Option<User>, _: &dyn askama::Values) -> askama::
         .unwrap_or(false))
 }
 
-pub fn is_manager(user: &Option<User>, _: &dyn askama::Values) -> askama::Result<bool> {
+pub fn is_manager(
+    user: &Option<UnsafeLoggedInUser>,
+    _: &dyn askama::Values,
+) -> askama::Result<bool> {
     Ok(user
         .as_ref()
         .map(|user| user.is_activated() && !user.is_disabled() && user.role == UserRole::Manager)
@@ -24,7 +36,7 @@ pub fn is_manager(user: &Option<User>, _: &dyn askama::Values) -> askama::Result
 }
 
 pub fn is_me(
-    current_user: &Option<User>,
+    current_user: &Option<UnsafeLoggedInUser>,
     _: &dyn askama::Values,
     user: &User,
 ) -> askama::Result<bool> {

--- a/nts-pool-management/templates/admin/users.html.j2
+++ b/nts-pool-management/templates/admin/users.html.j2
@@ -36,9 +36,11 @@
             <form action="/admin/users/{{ user.id }}/block" method="POST">
               <button class="action-btn" type="submit">Block</button>
             </form>
-            <form action="/admin/users/{{ user.id }}/login-as" method="POST">
-              <button class="action-btn" type="submit">Login as</button>
-            </form>
+            {% if app.parent_user.is_none() %}
+              <form action="/admin/users/{{ user.id }}/login-as" method="POST">
+                <button class="action-btn" type="submit">Login as</button>
+              </form>
+            {% endif %}
           {% endif %}
         {% endif %}
       </td>

--- a/nts-pool-management/templates/layout.html.j2
+++ b/nts-pool-management/templates/layout.html.j2
@@ -36,12 +36,16 @@
         </menu>
         <div>
           {% if let Some(u) = app.user %}
-              <span class="username">{{ u.email }}</span> <a href="/logout">Logout</a>
+            {% if let Some(parent) = app.parent_user %}
+              <span class="username" title="Logged in via {{ parent.email }}">{{ u.email }}</span> <a href="/logout">Exit login as</a>
             {% else %}
-              <a href="/login">Login</a>
+              <span class="username">{{ u.email }}</span> <a href="/logout">Logout</a>
             {% endif %}
-          </div>
-        </nav>
+          {% else %}
+            <a href="/login">Login</a>
+          {% endif %}
+        </div>
+      </nav>
       <header>
         {% block header %}{% endblock %}
       </header>


### PR DESCRIPTION
This also fixes #116 