### PR TITLE
Handle IpV4 and IpV6 properly

### DIFF
--- a/nts-pool-ke/src/config.rs
+++ b/nts-pool-ke/src/config.rs
@@ -288,6 +288,8 @@ pub struct KeyExchangeServer {
     pub domain: String,
     pub server_name: ServerName<'static>,
     pub regions: Vec<String>,
+    pub ipv4_capable: bool,
+    pub ipv6_capable: bool,
     pub connection_address: (String, u16),
 }
 
@@ -304,6 +306,10 @@ impl<'de> Deserialize<'de> for KeyExchangeServer {
             port: u16,
             #[serde(default)]
             regions: Vec<String>,
+            #[serde(default)]
+            ipv4_capable: Option<bool>,
+            #[serde(default)]
+            ipv6_capable: Option<bool>,
         }
 
         let bare = BareKeyExchangeServer::deserialize(deserializer)?;
@@ -321,6 +327,8 @@ impl<'de> Deserialize<'de> for KeyExchangeServer {
             server_name,
             regions: bare.regions,
             connection_address: (bare.domain.to_string(), bare.port),
+            ipv4_capable: bare.ipv4_capable.unwrap_or(true),
+            ipv6_capable: bare.ipv6_capable.unwrap_or(true),
         })
     }
 }
@@ -425,6 +433,8 @@ mod tests {
                     server_name: ServerName::try_from("foo.bar").unwrap(),
                     connection_address: (String::from("foo.bar"), 1234),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
                 KeyExchangeServer {
                     uuid: String::from("UUID-bar"),
@@ -432,6 +442,8 @@ mod tests {
                     server_name: ServerName::try_from("bar.foo").unwrap(),
                     connection_address: (String::from("bar.foo"), 4321),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
             ]
             .as_slice()

--- a/nts-pool-ke/src/servers/geo.rs
+++ b/nts-pool-ke/src/servers/geo.rs
@@ -269,6 +269,8 @@ mod tests {
                         server_name: ServerName::try_from("a.test").unwrap(),
                         connection_address: ("a.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                     KeyExchangeServer {
                         uuid: "UUID-b".into(),
@@ -276,6 +278,8 @@ mod tests {
                         server_name: ServerName::try_from("b.test").unwrap(),
                         connection_address: ("b.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                 ]
                 .into(),
@@ -317,6 +321,8 @@ mod tests {
                         server_name: ServerName::try_from("a.test").unwrap(),
                         connection_address: ("a.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                     KeyExchangeServer {
                         uuid: "UUID-b".into(),
@@ -324,6 +330,8 @@ mod tests {
                         server_name: ServerName::try_from("b.test").unwrap(),
                         connection_address: ("b.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                 ]
                 .into(),
@@ -358,6 +366,8 @@ mod tests {
                         server_name: ServerName::try_from("a.test").unwrap(),
                         connection_address: ("a.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                     KeyExchangeServer {
                         uuid: "UUID-b".into(),
@@ -365,6 +375,8 @@ mod tests {
                         server_name: ServerName::try_from("b.test").unwrap(),
                         connection_address: ("b.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                 ]
                 .into(),
@@ -399,6 +411,8 @@ mod tests {
                         server_name: ServerName::try_from("global.test").unwrap(),
                         connection_address: ("global.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                     KeyExchangeServer {
                         uuid: "UUID-eu".into(),
@@ -406,6 +420,8 @@ mod tests {
                         server_name: ServerName::try_from("eu.test").unwrap(),
                         connection_address: ("eu.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                     KeyExchangeServer {
                         uuid: "UUID-gb".into(),
@@ -413,6 +429,8 @@ mod tests {
                         server_name: ServerName::try_from("gb.test").unwrap(),
                         connection_address: ("gb.test".into(), 4460),
                         regions: vec![],
+                        ipv4_capable: true,
+                        ipv6_capable: true,
                     },
                 ]
                 .into(),

--- a/nts-pool-ke/src/servers/roundrobin.rs
+++ b/nts-pool-ke/src/servers/roundrobin.rs
@@ -189,6 +189,8 @@ mod tests {
                     server_name: ServerName::try_from("a.test").unwrap(),
                     connection_address: ("a.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
                 KeyExchangeServer {
                     uuid: "UUID-b".into(),
@@ -196,6 +198,8 @@ mod tests {
                     server_name: ServerName::try_from("b.test").unwrap(),
                     connection_address: ("b.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
             ]
             .into(),
@@ -222,6 +226,8 @@ mod tests {
                     server_name: ServerName::try_from("a.test").unwrap(),
                     connection_address: ("a.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
                 KeyExchangeServer {
                     uuid: "UUID-b".into(),
@@ -229,6 +235,8 @@ mod tests {
                     server_name: ServerName::try_from("b.test").unwrap(),
                     connection_address: ("b.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
             ]
             .into(),
@@ -257,6 +265,8 @@ mod tests {
                     server_name: ServerName::try_from("a.test").unwrap(),
                     connection_address: ("a.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
                 KeyExchangeServer {
                     uuid: "UUID-b".into(),
@@ -264,6 +274,8 @@ mod tests {
                     server_name: ServerName::try_from("b.test").unwrap(),
                     connection_address: ("b.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
             ]
             .into(),
@@ -292,6 +304,8 @@ mod tests {
                     server_name: ServerName::try_from("a.test").unwrap(),
                     connection_address: ("a.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
                 KeyExchangeServer {
                     uuid: "UUID-b".into(),
@@ -299,6 +313,8 @@ mod tests {
                     server_name: ServerName::try_from("b.test").unwrap(),
                     connection_address: ("b.test".into(), 4460),
                     regions: vec![],
+                    ipv4_capable: true,
+                    ipv6_capable: true,
                 },
             ]
             .into(),

--- a/nts-pool-ke/testdata/testservers.json
+++ b/nts-pool-ke/testdata/testservers.json
@@ -1,5 +1,5 @@
 [
-    {"uuid": "UUID-a", "domain": "a.test", "port": 4460, "regions": ["EUROPE", "NL"]},
-    {"uuid": "UUID-b", "domain": "b.test", "port": 4460},
-    {"uuid": "UUID-c", "domain": "c.test", "port": 4460, "regions": ["ASIA", "NL", "BE"]}
+    {"uuid": "UUID-a", "domain": "a.test", "port": 4460, "regions": ["EUROPE", "NL"], "ipv4_capable": true, "ipv6_capable": true},
+    {"uuid": "UUID-b", "domain": "b.test", "port": 4460, "ipv4_capable": false},
+    {"uuid": "UUID-c", "domain": "c.test", "port": 4460, "regions": ["ASIA", "NL", "BE"], "ipv6_capable": false}
 ]

--- a/nts-pool-management/src/routes/monitoring.rs
+++ b/nts-pool-management/src/routes/monitoring.rs
@@ -7,9 +7,15 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+enum IpVersion {
+    IpV4,
+    IpV6,
+}
+
 #[derive(Serialize, Deserialize)]
 struct ProbeControlCommand {
-    timesources: Vec<String>,
+    timesources: Vec<(IpVersion, String)>,
     poolke: String,
     result_endpoint: String,
     result_batchsize: usize,
@@ -22,7 +28,10 @@ struct ProbeControlCommand {
 
 pub async fn get_work() -> impl IntoResponse {
     Json(ProbeControlCommand {
-        timesources: vec!["UUID-A".into(), "UUID-B".into()],
+        timesources: vec![
+            (IpVersion::IpV4, "UUID-A".into()),
+            (IpVersion::IpV4, "UUID-B".into()),
+        ],
         poolke: "localhost".into(),
         result_endpoint: "http://localhost:3000/monitoring/submit".into(),
         result_batchsize: 4,


### PR DESCRIPTION
This pull request provides support for properly dealing with ipv4 and ipv6 in various places, ensuring clients speaking only one of the two get an appropriate server.