### PR TITLE
Enforce more constraints on hostname,port combo provided by client.

### DIFF
--- a/nts-pool-management/migrations/20251217083055_timesource_unique.down.sql
+++ b/nts-pool-management/migrations/20251217083055_timesource_unique.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DROP INDEX time_sources_hostname_port_unique;
+ALTER TABLE time_sources ALTER COLUMN port DROP NOT NULL;
+ALTER TABLE time_sources ALTER COLUMN port DROP DEFAULT;

--- a/nts-pool-management/migrations/20251217083055_timesource_unique.up.sql
+++ b/nts-pool-management/migrations/20251217083055_timesource_unique.up.sql
@@ -1,0 +1,5 @@
+-- Add up migration script here
+UPDATE time_sources SET port=4460 WHERE port IS NULL;
+ALTER TABLE time_sources ALTER COLUMN port SET DEFAULT 4460;
+ALTER TABLE time_sources ALTER COLUMN port SET NOT NULL;
+CREATE UNIQUE INDEX time_sources_hostname_port_unique ON time_sources (hostname, port) WHERE NOT deleted;

--- a/nts-pool-management/src/routes/management.rs
+++ b/nts-pool-management/src/routes/management.rs
@@ -208,7 +208,7 @@ pub async fn create_time_source(
     match time_source::create(
         &state.db,
         user.id,
-        new_time_source.clone().try_into()?,
+        new_time_source.clone().into_new_source(&app)?,
         state.config.base_secret_index,
         &geodb,
     )
@@ -224,11 +224,10 @@ pub async fn create_time_source(
             ),
         })
         .into_response()),
-        Err(_) => Ok((
-            cookies.flash_error("Could not add time source".to_string()),
-            Redirect::to(TIME_SOURCES_ENDPOINT),
-        )
-            .into_response()),
+        Err(_) => {
+            cookies.flash_error("Could not add duplicate time source".to_string());
+            Ok((cookies, Redirect::to(TIME_SOURCES_ENDPOINT)).into_response())
+        }
     }
 }
 


### PR DESCRIPTION
This provides new checks for uniqueness, and not being unwanted names like localhost, .local domains or the pool domain.

Fixes #316

Note: this does not implement further restrictions on binding hostnames to a single user. That would require significantly more effort to enforce. I have created a new issue to cover just that.