### PR TITLE
[Monitor] Make more probe errors failures for the remote.

### DIFF
--- a/nts-pool-shared/src/monitoring.rs
+++ b/nts-pool-shared/src/monitoring.rs
@@ -60,6 +60,9 @@ pub struct KeyExchangeProbeResult {
 pub enum SecuredNtpProbeStatus {
     Success,
     DnsLookupFailed,
+    CouldNotConnect,
+    CouldNotSend,
+    CouldNotReceive,
     NtsNak,
     Deny,
     Timeout,


### PR DESCRIPTION
This ensures we don't accidentally blame ourselves for problems the remote creates, even if they show up in unexpected ways.