### PR TITLE
Make the 0-3 subdomains disjunct, also for geographic zones.

### DIFF
--- a/nts-pool-ke/src/servers.rs
+++ b/nts-pool-ke/src/servers.rs
@@ -68,11 +68,12 @@ pub trait ServerManager: Sync + Send {
     /// any denied servers.
     ///
     /// Denied servers need not be respected if no other options are available
-    fn assign_server(
-        &self,
+    fn assign_server<'a>(
+        &'a self,
         address: SocketAddr,
+        domain: Option<&'_ str>,
         denied_servers: &[Cow<'_, str>],
-    ) -> Option<Self::Server<'_>>;
+    ) -> Option<Self::Server<'a>>;
 
     /// Select a server with given UUID. This is used for making KE connections
     /// in the monitoring.

--- a/nts-pool-ke/src/servers/roundrobin.rs
+++ b/nts-pool-ke/src/servers/roundrobin.rs
@@ -63,6 +63,7 @@ impl ServerManager for RoundRobinServerManager {
     fn assign_server(
         &self,
         _address: SocketAddr,
+        _domain: Option<&str>,
         denied_servers: &[Cow<'_, str>],
     ) -> Option<Self::Server<'_>> {
         if self.servers.is_empty() {
@@ -248,10 +249,10 @@ mod tests {
         };
 
         let first_server = manager
-            .assign_server("127.0.0.1:4460".parse().unwrap(), &[])
+            .assign_server("127.0.0.1:4460".parse().unwrap(), None, &[])
             .unwrap();
         let second_server = manager
-            .assign_server("127.0.0.1:4460".parse().unwrap(), &[])
+            .assign_server("127.0.0.1:4460".parse().unwrap(), None, &[])
             .unwrap();
         assert_ne!(first_server.name(), second_server.name());
     }
@@ -342,12 +343,12 @@ mod tests {
         };
 
         let server = manager
-            .assign_server("127.0.0.1:4460".parse().unwrap(), &["a.test".into()])
+            .assign_server("127.0.0.1:4460".parse().unwrap(), None, &["a.test".into()])
             .unwrap();
         assert_ne!(server.name().as_ref(), "a.test");
 
         let server = manager
-            .assign_server("127.0.0.1:4460".parse().unwrap(), &["a.test".into()])
+            .assign_server("127.0.0.1:4460".parse().unwrap(), None, &["a.test".into()])
             .unwrap();
         assert_ne!(server.name().as_ref(), "a.test");
     }
@@ -394,12 +395,14 @@ mod tests {
         let first = manager
             .assign_server(
                 "127.0.0.1:4460".parse().unwrap(),
+                None,
                 &["a.test".into(), "b.test".into()],
             )
             .unwrap();
         let second = manager
             .assign_server(
                 "127.0.0.1:4460".parse().unwrap(),
+                None,
                 &["a.test".into(), "b.test".into()],
             )
             .unwrap();


### PR DESCRIPTION
This implements functional use of the 0-3 subdomains. They work on any subdomain the kelb accepts.