### PR TITLE
Widen main container width

### DIFF
--- a/nts-pool-management/assets/main.css
+++ b/nts-pool-management/assets/main.css
@@ -7,7 +7,7 @@ body {
 .appcontainer {
   display: grid;
   height: 100vh;
-  grid-template-columns: auto minmax(50ch, 1024px) auto;
+  grid-template-columns: auto minmax(50ch, var(--container-width)) auto;
   grid-template-rows: var(--space-lg) 7rem 1fr var(--space-lg);
   grid-template-areas:
     "nav    nav    nav"

--- a/nts-pool-management/assets/variables.css
+++ b/nts-pool-management/assets/variables.css
@@ -31,7 +31,8 @@
   --space-md: 2.5rem;
   --space-lg: 5rem;
   --space-xl: 10rem;
-
+  --container-width: 1280px;
+  
   --border-radius: 0.75rem;
   --border-width: 2px;
 


### PR DESCRIPTION
Currently some tables are clipped on the right side when they exceed the `<main>` container width. As a quick fix we just widen the width of the container, until we come up with a permanent solution to handling wide (table) content