### PR TITLE
Make signature validity twice as long as the ttl.

### DIFF
--- a/nts-pool-dns/src/main.rs
+++ b/nts-pool-dns/src/main.rs
@@ -185,7 +185,7 @@ async fn run_nts_pool_dns(config: Config) -> eyre::Result<()> {
         geolocation_db_path: config.zone.geolocation_db_path.clone(),
         algorithm: Algorithm::RSASHA256,
         sign_duration: config.zone.sign_duration,
-        ttl: config.zone.sign_duration,
+        ttl: config.zone.sign_duration / 2,
     };
     let geo_handler = Arc::new(
         GeoHandler::new(geo_config)


### PR DESCRIPTION
This prevents problems with cached dnssec records.

Closes #508